### PR TITLE
No \ead{} generated for authors without e-mail.

### DIFF
--- a/elsevier.xelatex
+++ b/elsevier.xelatex
@@ -12,7 +12,9 @@
 
 $for(author)$
 \author[$author.group$]{$author.name$}
+$if(author.email)$
 \ead{$author.email$}
+$endif$
 $endfor$
 
 \cortext[cor1]{Corresponding author}


### PR DESCRIPTION
For authors with no "email" variable in the Markdown YAML header, \ead{} macros with no argument were generated. Now, they get no \ead{} and their names do not appear in the "Corresponding author" footnote.